### PR TITLE
Do not use default parameter in function signature

### DIFF
--- a/view/frontend/web/js/checkout/shipping_method/show-myparcel-shipping-method.js
+++ b/view/frontend/web/js/checkout/shipping_method/show-myparcel-shipping-method.js
@@ -93,8 +93,9 @@ define(
             return true;
         }
 
-        function showDeliveryRadio(extraOption, typeTitle = '') {
+        function showDeliveryRadio(extraOption, typeTitle) {
 
+            typeTitle = (typeof typeTitle !== 'undefined') ? typeTitle : '';
             jQuery("td[id^='label_carrier_" + window.mypa.data.general.parent_method + "']").parent().hide();
             jQuery("td[id^='label_carrier_"+ extraOption +"']").parent().show();
 


### PR DESCRIPTION
Because IE11 does not support default parameters, this change removes the default parameter and handles the default value in the function body.