### PR TITLE
Add correct migration

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -173,7 +173,8 @@ class UpgradeData implements UpgradeDataInterface
             );
         }
 
-        // The options digital stamp and mailbox were not showing on the product options
+        // This migration is necessary because the migration for version 3.1.0 was not correct used.
+        // The data in the database was not filled in correctly, that was the reason why DPZ and BBP were not visible in the settings.
         if (version_compare($context->getVersion(), '3.1.4', '<=')) {
             $setup->startSetup();
             /** @var EavSetup $eavSetup */

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -173,6 +173,69 @@ class UpgradeData implements UpgradeDataInterface
             );
         }
 
+        // The options digital stamp and mailbox were not showing on the product options
+        if (version_compare($context->getVersion(), '3.1.4', '<=')) {
+            $setup->startSetup();
+            /** @var EavSetup $eavSetup */
+            $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
+
+            // Add attributes to the eav/attribute
+            $eavSetup->addAttribute(
+                \Magento\Catalog\Model\Product::ENTITY,
+                'myparcel_digital_stamp',
+                [
+                    'group'                   => 'MyParcel Options',
+                    'type'                    => 'int',
+                    'backend'                 => '',
+                    'frontend'                => '',
+                    'label'                   => 'Fit in digital stamp',
+                    'input'                   => 'boolean',
+                    'class'                   => '',
+                    'source'                  => '',
+                    'global'                  => ScopedAttributeInterface::SCOPE_GLOBAL,
+                    'visible'                 => true,
+                    'required'                => false,
+                    'user_defined'            => true,
+                    'default'                 => '0',
+                    'searchable'              => true,
+                    'filterable'              => true,
+                    'comparable'              => true,
+                    'visible_on_front'        => false,
+                    'used_in_product_listing' => false,
+                    'unique'                  => false,
+                    'apply_to'                => '',
+                ]
+            );
+
+             // Add attributes to the eav/attribute
+            $eavSetup->addAttribute(
+                \Magento\Catalog\Model\Product::ENTITY,
+                'myparcel_fit_in_mailbox',
+                [
+                    'group'                   => 'MyParcel Options',
+                    'type'                    => 'varchar',
+                    'backend'                 => 'Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend',
+                    'label'                   => 'Fit in Mailbox',
+                    'input'                   => 'select',
+                    'class'                   => '',
+                    'source'                  => 'MyParcelNL\Magento\Model\Source\FitInMailboxOptions',
+                    'global'                  => \Magento\Catalog\Model\ResourceModel\Eav\Attribute::SCOPE_GLOBAL,
+                    'visible'                 => true,
+                    'required'                => false,
+                    'user_defined'            => true,
+                    'default'                 => null,
+                    'searchable'              => false,
+                    'filterable'              => false,
+                    'comparable'              => false,
+                    'visible_on_front'        => false,
+                    'used_in_product_listing' => true,
+                    'unique'                  => false,
+                    'apply_to'                => 'simple,configurable,bundle,grouped',
+                    'group'                   => 'General'
+                ]
+            );
+        }
+
         $setup->endSetup();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "myparcelnl/magento",
     "description": "A Magento 2 module that creates MyParcel labels",
     "type": "magento2-module",
-    "version": "3.1.4-beta.1",
+    "version": "3.1.4-beta.2",
     "homepage": "https://www.myparcel.nl",
     "keywords": ["MyParcel", "My Parcel", "Post NL", "PostNL", "Magento 2"],
     "license": "GPL-3.0-or-later",


### PR DESCRIPTION
When there is a update about a product option Magento replaced the database row with the data in the migration.

The migration in https://github.com/myparcelnl/magento/pull/321 don't work and hide the BBP and the DPZ options