### PR TITLE
Error handling fix

### DIFF
--- a/Controller/Adminhtml/Shipment/CreateAndPrintMyParcelTrack.php
+++ b/Controller/Adminhtml/Shipment/CreateAndPrintMyParcelTrack.php
@@ -108,7 +108,7 @@ class CreateAndPrintMyParcelTrack extends \Magento\Framework\App\Action\Action
                 ->downloadPdfOfLabels();
 
         } catch (\Exception $e) {
-            if (count($this->messageManager->getMessages()) == 0) {
+            if (count($this->messageManager->getMessages()->getItems()) == 0) {
                 $this->messageManager->addErrorMessage(__('An error has occurred while creating a MyParcel label. You may not have entered the correct API key. To get your personal API credentials you should contact MyParcel.'));
                 $this->_objectManager->get('Psr\Log\LoggerInterface')->critical($e);
             }


### PR DESCRIPTION
While working on a bug for a customer that uses this plugin I noticed this bug in the error handling code. The getMessages function returns a Collection object that does not implement a Countable interface. It does however have a getItems() function that returns an array which is countable. Alternatively the Collection class also contains a getCount function which could be used.