### PR TITLE
Reload Order Collection after creating shipments

### DIFF
--- a/Controller/Adminhtml/Order/CreateAndPrintMyParcelTrack.php
+++ b/Controller/Adminhtml/Order/CreateAndPrintMyParcelTrack.php
@@ -103,6 +103,8 @@ class CreateAndPrintMyParcelTrack extends \Magento\Framework\App\Action\Action
         $this->orderCollection
             ->setOptionsFromParameters()
             ->setNewMagentoShipment();
+        
+        $this->orderCollection->reload();
 
         if (!$this->orderCollection->hasShipment()) {
             $this->messageManager->addErrorMessage(__(MagentoOrderCollection::ERROR_ORDER_HAS_NO_SHIPMENT));


### PR DESCRIPTION
This fixes a bug a customer of ours encountered where this action showed the error "No shipment can be made with this order. Shipments can not be created if the status is On Hold or if the product is digital." when attempting to print the label for certain orders. Even though this error was shown, a shipment was created, but the tracking information was incomplete. 
As far as I understand the issue arises because the, while the shipments are created in the database, the in-memory representations of the orders (that are checked in the orderCollection::hasShipment() function) are not updated with these new shipments. Resulting in the hasShipment call returning false. By reloading the order collection the in-memory references are made up-to-date and the system seems to work.