### PR TITLE
Fix false carrier causing type errors

### DIFF
--- a/Observer/NewShipment.php
+++ b/Observer/NewShipment.php
@@ -97,6 +97,10 @@ class NewShipment implements ObserverInterface
         $trackTraceHolders = [];
         $i                 = 1;
 
+        if (isset($options['carrier']) && $options['carrier'] === false) {
+            unset($options['carrier']);
+        }
+
         while ($i <= $amount) {
 
             // Set MyParcel options

--- a/Observer/NewShipment.php
+++ b/Observer/NewShipment.php
@@ -97,7 +97,7 @@ class NewShipment implements ObserverInterface
         $trackTraceHolders = [];
         $i                 = 1;
 
-        if (isset($options['carrier']) && $options['carrier'] === false) {
+        if (isset($options['carrier']) && false === $options['carrier']) {
             unset($options['carrier']);
         }
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Magento 2
 Voor de handleiding en meer informatie ga naar: 
-https://myparcel.github.io/magento/
+https://myparcelnl.github.io/magento/


### PR DESCRIPTION
We were receiving the following error when creating a shipment from the backend:
```
Uncaught TypeError: Return value of MyParcelNL\Sdk\src\Adapter\DeliveryOptions\AbstractDeliveryOptionsAdapter::getCarrier() must be of the type string or null, bool returned in vendor/myparcelnl/sdk/src/Adapter/DeliveryOptions/AbstractDeliveryOptionsAdapter.php:88
```