### PR TITLE
fix: trim spaces from postcode

### DIFF
--- a/Controller/Adminhtml/Order/CreateAndPrintMyParcelTrack.php
+++ b/Controller/Adminhtml/Order/CreateAndPrintMyParcelTrack.php
@@ -163,7 +163,7 @@ class CreateAndPrintMyParcelTrack extends \Magento\Framework\App\Action\Action
         foreach ($orderIds as $orderId) {
             $orderData          = $order->load($orderId);
             $fullStreet         = implode(" ", $order->getShippingAddress()->getStreet());
-            $postcode           = $order->getShippingAddress()->getPostcode();
+            $postcode           = preg_replace('/\s+/', '', $order->getShippingAddress()->getPostcode());
             $destinationCountry = $order->getShippingAddress()->getCountryId();
             $keyOrderId         = array_search($orderId, $orderIds);
 

--- a/Model/Sales/TrackTraceHolder.php
+++ b/Model/Sales/TrackTraceHolder.php
@@ -179,7 +179,7 @@ class TrackTraceHolder
         try {
             $this->consignment
                 ->setFullStreet($address->getData('street'))
-                ->setPostalCode($address->getPostcode());
+                ->setPostalCode(preg_replace('/\s+/', '', $address->getPostcode()));
         } catch (\Exception $e) {
             $errorHuman = 'An error has occurred while validating order number ' . $shipment->getOrder()->getIncrementId() . '. Check address.';
             $this->messageManager->addErrorMessage($errorHuman . ' View log file for more information.');


### PR DESCRIPTION
- Some consumers put too many spaces between the numbers and letters of a postcode.
- In addition, there are also consumers that place a space after the postcode. All these extra spaces must be removed, so that the export functions properly.