### PR TITLE
fix: Fix bug when Magento MSI is not enabled

### DIFF
--- a/Model/Source/SourceItem.php
+++ b/Model/Source/SourceItem.php
@@ -48,7 +48,7 @@ class SourceItem
 
             return $this->sourceItemRepository->getList($searchCriteria)->getItems();
         } 
-        return [];        
+        return [];
     }
 
     /**

--- a/Model/Source/SourceItem.php
+++ b/Model/Source/SourceItem.php
@@ -29,7 +29,7 @@ class SourceItem
         Manager $moduleManager
     ) {
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
-        $this->moduleManager = $moduleManager;
+        $this->moduleManager         = $moduleManager;
         $this->setSourceItemRepositoryWhenInventoryApiEnabled();
     }
 
@@ -47,10 +47,8 @@ class SourceItem
                 ->create();
 
             return $this->sourceItemRepository->getList($searchCriteria)->getItems();
-        } else {
-            return [];
-        }
-
+        } 
+        return [];        
     }
 
     /**
@@ -60,7 +58,7 @@ class SourceItem
      *
      * @return void
      */
-    private function setSourceItemRepositoryWhenInventoryApiEnabled()
+    private function setSourceItemRepositoryWhenInventoryApiEnabled(): void
     {
         if ($this->moduleManager->isEnabled('Magento_InventoryApi')) {
             $this->sourceItemRepository = $this->objectManager->get(SourceItemRepositoryInterface::class);

--- a/Model/Source/SourceItem.php
+++ b/Model/Source/SourceItem.php
@@ -22,7 +22,7 @@ class SourceItem
     /**
      * @var SourceItemRepositoryInterface
      */
-    private $sourceItemRepository = null;
+    private $sourceItemRepository;
 
     public function __construct(
         SearchCriteriaBuilder $searchCriteriaBuilder,

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "myparcelnl/magento",
     "description": "A Magento 2 module that creates MyParcel labels",
     "type": "magento2-module",
-    "version": "4.1.8-RC.1",
+    "version": "4.1.8",
     "homepage": "https://www.myparcel.nl",
     "keywords": ["MyParcel", "myparcel", "PostNL", "postnl", "Magento 2"],
     "license": "GPL-3.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "myparcelnl/magento",
     "description": "A Magento 2 module that creates MyParcel labels",
     "type": "magento2-module",
-    "version": "4.1.7",
+    "version": "4.1.8-beta.1",
     "homepage": "https://www.myparcel.nl",
     "keywords": ["MyParcel", "myparcel", "PostNL", "postnl", "Magento 2"],
     "license": "GPL-3.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "myparcelnl/magento",
     "description": "A Magento 2 module that creates MyParcel labels",
     "type": "magento2-module",
-    "version": "4.1.8-beta.1",
+    "version": "4.1.8-RC.1",
     "homepage": "https://www.myparcel.nl",
     "keywords": ["MyParcel", "myparcel", "PostNL", "postnl", "Magento 2"],
     "license": "GPL-3.0-or-later",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd" >
-    <module name="MyParcelNL_Magento" setup_version="4.1.7">
+    <module name="MyParcelNL_Magento" setup_version="4.1.8">
         <sequence>
             <module name="Magento_Sales"/>
         </sequence>


### PR DESCRIPTION
When Magento MSI is not enabled, the `bin/magento setup:di:command` fails on `Model/Source/SourceItem.php`
This is because the objectmanager cannot instantiate the `Magento\InventoryApi\Api\SourceItemRepositoryInterface`
```
Area configuration aggregation... 5/9 [===============>------------]  55% 18 secs 334.0 MiB
In ClassReader.php line 45:
                                                                                                                                                                                                           
  Impossible to process constructor argument Parameter #1 [ <required> Magento\InventoryApi\Api\SourceItemRepositoryInterface $sourceItemRepository ] of MyParcelNL\Magento\Model\Source\SourceItem class                                                                                                              

In ClassReader.php line 34:
                                                                               
  Class Magento\InventoryApi\Api\SourceItemRepositoryInterface does not exist  
                                                                               
111
This PR applies the same fix as PR #577 to the SourceItem class itself