### PR TITLE
Fix issue with fetching order with non-numeric increment ID

### DIFF
--- a/Plugin/Magento/Sales/Api/Data/OrderExtension.php
+++ b/Plugin/Magento/Sales/Api/Data/OrderExtension.php
@@ -63,7 +63,8 @@ class OrderExtension
             [$searchColumn, $searchValue] = $this->useEntityId(end($explodePath));
         }
 
-        if (empty($searchValue)) {
+        // Ensure that the search value is numeric or textual to prevent SQL injections
+        if (preg_match('/^[a-zA-Z-0-9-_]+$/', $searchValue) < 1) {
             return '';
         }
 
@@ -71,7 +72,13 @@ class OrderExtension
         $sql = $connection
             ->select('myparcel_delivery_options')
             ->from($tableName)
-            ->where($searchColumn . ' = ' . (int) $searchValue);
+            ->where(
+                sprintf(
+                    '%s = "%s"',
+                    $searchColumn,
+                    $searchValue
+                )
+            );
 
         $result = $connection->fetchAll($sql); // Gives associated array, table fields as key in array.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "myparcelnl/magento",
     "description": "A Magento 2 module that creates MyParcel labels",
     "type": "magento2-module",
-    "version": "4.1.8-RC.1",
+    "version": "4.1.8",
     "homepage": "https://www.myparcel.nl",
     "keywords": ["MyParcel", "myparcel", "PostNL", "postnl", "Magento 2"],
     "license": "GPL-3.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "myparcelnl/magento",
     "description": "A Magento 2 module that creates MyParcel labels",
     "type": "magento2-module",
-    "version": "4.1.8-beta.1",
+    "version": "4.1.8-RC.1",
     "homepage": "https://www.myparcel.nl",
     "keywords": ["MyParcel", "myparcel", "PostNL", "postnl", "Magento 2"],
     "license": "GPL-3.0-or-later",


### PR DESCRIPTION
When using non-numeric order increment IDs, the script will load
all orders in the webshop, causing an out of memory error when
having a lot of orders.

This is fixed by always using a string, since order increment IDs
in Magento are stored in a VARCHAR table column.

To prevent possible SQL injections, a check has been added to the
script as well.