### PR TITLE
fix: use BaseConsignment where you need an instance

### DIFF
--- a/Block/Sales/OrderAction.php
+++ b/Block/Sales/OrderAction.php
@@ -15,7 +15,7 @@
 namespace MyParcelNL\Magento\Block\Sales;
 
 use Magento\Backend\Block\Template\Context;
-use MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment;
+use MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment;
 use \Magento\Framework\Registry;
 
 class OrderAction extends OrdersAction
@@ -25,20 +25,20 @@ class OrderAction extends OrdersAction
      */
     private $order;
     /**
-     * @var \MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment
+     * @var \MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment
      */
     private $consignment;
 
     /**
      * @param Context $context
      * @param \Magento\Framework\Registry $registry
-     * @param \MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment $consignment
+     * @param \MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment $consignment
      * @param array $data
      */
     public function __construct(
         Context $context,
         Registry $registry,
-        AbstractConsignment $consignment,
+        BaseConsignment $consignment,
         array $data = []
     ) {
         // Set order

--- a/Block/Sales/ShipmentAction.php
+++ b/Block/Sales/ShipmentAction.php
@@ -17,7 +17,7 @@ namespace MyParcelNL\Magento\Block\Sales;
 use Magento\Backend\Block\Template\Context;
 use Magento\Framework\Registry;
 use Magento\Sales\Model\Order\Shipment;
-use MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment;
+use MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment;
 
 class ShipmentAction extends OrdersAction
 {
@@ -30,7 +30,7 @@ class ShipmentAction extends OrdersAction
      */
     private $shipment;
     /**
-     * @var \MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment
+     * @var \MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment
      */
     private $consignment;
 
@@ -38,14 +38,14 @@ class ShipmentAction extends OrdersAction
      * @param Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Sales\Model\Order\Shipment $shipment
-     * @param \MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment $consignment
+     * @param \MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment $consignment
      * @param array $data
      */
     public function __construct(
         Context $context,
         Registry $registry,
         Shipment $shipment,
-        AbstractConsignment $consignment,
+        BaseConsignment $consignment,
         array $data = []
     ) {
         // Set shipment and order

--- a/Model/Checkout/PackageType.php
+++ b/Model/Checkout/PackageType.php
@@ -4,7 +4,6 @@ namespace MyParcelNL\Magento\Model\Checkout;
 
 use MyParcelNL\Magento\Api\PackageTypeInterface;
 use MyParcelNL\Magento\Model\Quote\Checkout;
-use MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment;
 
 /**
  * @since 3.0.0

--- a/Model/Quote/SaveOrderBeforeSalesModelQuoteObserver.php
+++ b/Model/Quote/SaveOrderBeforeSalesModelQuoteObserver.php
@@ -37,10 +37,7 @@ class SaveOrderBeforeSalesModelQuoteObserver implements ObserverInterface
      * @var DeliveryRepository
      */
     private $delivery;
-    /**
-     * @var AbstractConsignment
-     */
-    private $consignment;
+
     /**
      * @var array
      */
@@ -50,16 +47,13 @@ class SaveOrderBeforeSalesModelQuoteObserver implements ObserverInterface
      * SaveOrderBeforeSalesModelQuoteObserver constructor.
      *
      * @param DeliveryRepository  $delivery
-     * @param AbstractConsignment $consignment
      * @param Checkout            $checkoutHelper
      */
     public function __construct(
         DeliveryRepository $delivery,
-        AbstractConsignment $consignment,
         Checkout $checkoutHelper
     ) {
         $this->delivery      = $delivery;
-        $this->consignment   = $consignment;
         $this->parentMethods = explode(',', $checkoutHelper->getGeneralConfig('shipping_methods/methods'));
     }
 

--- a/Model/Sales/MagentoCollection.php
+++ b/Model/Sales/MagentoCollection.php
@@ -19,7 +19,7 @@ use MyParcelNL\Magento\Model\Source\ReturnInTheBox;
 use MyParcelNL\Magento\Observer\NewShipment;
 use MyParcelNL\Magento\Ui\Component\Listing\Column\TrackAndTrace;
 use MyParcelNL\Sdk\src\Helper\MyParcelCollection;
-use MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment;
+use MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment;
 
 /**
  * Class MagentoOrderCollection
@@ -192,12 +192,12 @@ class MagentoCollection implements MagentoCollectionInterface
     /**
      * Add MyParcel consignment to collection
      *
-     * @param $consignment AbstractConsignment
+     * @param $consignment BaseConsignment
      *
      * @return $this
      * @throws \Exception
      */
-    public function addConsignment(AbstractConsignment $consignment)
+    public function addConsignment(BaseConsignment $consignment)
     {
         $this->myParcelCollection->addConsignment($consignment);
 

--- a/Model/Sales/MagentoOrderCollection.php
+++ b/Model/Sales/MagentoOrderCollection.php
@@ -21,7 +21,6 @@ use MyParcelNL\Magento\Model\Source\ReturnInTheBox;
 use MyParcelNL\Magento\Model\Source\SourceItem;
 use MyParcelNL\Sdk\src\Factory\DeliveryOptionsAdapterFactory;
 use MyParcelNL\Sdk\src\Helper\MyParcelCollection;
-use MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment;
 use MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment;
 use MyParcelNL\Sdk\src\Collection\Fulfilment\OrderCollection;
 use MyParcelNL\Sdk\src\Model\Fulfilment\Order as FulfilmentOrder;
@@ -357,9 +356,9 @@ class MagentoOrderCollection extends MagentoCollection
             ->generateReturnConsignments(
                 false,
                 function (
-                    BaseConsignment $returnConsignment,
-                    BaseConsignment $parent
-                ) use ($returnOptions): BaseConsignment {
+                    AbstractConsignment $returnConsignment,
+                    AbstractConsignment $parent
+                ) use ($returnOptions): AbstractConsignment {
                     $returnConsignment->setLabelDescription(
                         'Return: ' . $parent->getLabelDescription() .
                         ' This label is valid until: ' . date("d-m-Y", strtotime("+ 28 days"))

--- a/Model/Sales/MagentoOrderCollection.php
+++ b/Model/Sales/MagentoOrderCollection.php
@@ -21,6 +21,7 @@ use MyParcelNL\Magento\Model\Source\ReturnInTheBox;
 use MyParcelNL\Magento\Model\Source\SourceItem;
 use MyParcelNL\Sdk\src\Factory\DeliveryOptionsAdapterFactory;
 use MyParcelNL\Sdk\src\Helper\MyParcelCollection;
+use MyParcelNL\Sdk\src\Model\Consignment\BaseConsignment;
 use MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment;
 use MyParcelNL\Sdk\src\Collection\Fulfilment\OrderCollection;
 use MyParcelNL\Sdk\src\Model\Fulfilment\Order as FulfilmentOrder;
@@ -356,9 +357,9 @@ class MagentoOrderCollection extends MagentoCollection
             ->generateReturnConsignments(
                 false,
                 function (
-                    AbstractConsignment $returnConsignment,
-                    AbstractConsignment $parent
-                ) use ($returnOptions): AbstractConsignment {
+                    BaseConsignment $returnConsignment,
+                    BaseConsignment $parent
+                ) use ($returnOptions): BaseConsignment {
                     $returnConsignment->setLabelDescription(
                         'Return: ' . $parent->getLabelDescription() .
                         ' This label is valid until: ' . date("d-m-Y", strtotime("+ 28 days"))

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "~5.6.5 || ^7.0",
-        "myparcelnl/sdk": "~5.3.0-beta.1",
+        "myparcelnl/sdk": "~v6.0.0-beta.6",
         "magento/product-community-edition": "~2.3.6 || ~2.4.0"
     },
     "require-dev": {


### PR DESCRIPTION
In de gecompileerde code wordt bij OrderAction en ShipmentAction de consignment geinstantieerd lijkt het, en dit kunnen we ook proefondervindelijk vaststellen. Door de BaseConsigment te gebruiken gaat dit goed (itt de AbstractConsignment). Er wordt geen specifieke consignment doorgegeven, alleen worden methods gebruikt.