### PR TITLE
prevent php 8.1 deprecation notice in strtotime

### DIFF
--- a/Block/Sales/View.php
+++ b/Block/Sales/View.php
@@ -78,7 +78,7 @@ class View extends AbstractOrder
                     $html .= __($data['packageType'] . ' ');
                 }
 
-                $dateTime = date('d-m-Y H:i', strtotime($data['date']));
+                $dateTime = date('d-m-Y H:i', strtotime($data['date'] ?? ''));
                 $html .= __('Deliver:') . ' ' . $dateTime;
 
                 if (key_exists('shipmentOptions', $data)) {


### PR DESCRIPTION
I got this error;

![image](https://user-images.githubusercontent.com/431360/214328997-5c8a1d18-e9c0-4b56-91aa-724597850517.png)

Fix proof:

```
php > $data['date'] = null;
php > $dateTime = date('d-m-Y H:i', strtotime($data['date']));
PHP Deprecated:  strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in php shell code on line 1
PHP Stack trace:
PHP   1. {main}() php shell code:0
PHP   2. strtotime($datetime = NULL) php shell code:1

Deprecated: strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in php shell code on line 1

Call Stack:
   32.4666     603888   1. {main}() php shell code:0
   32.4666     603888   2. strtotime($datetime = NULL) php shell code:1

php > $dateTime = date('d-m-Y H:i', strtotime($data['date'] ?? ''));
php > var_dump($dateTime);
php shell code:1:
string(16) "01-01-1970 00:00"
```

Resolves #739 
