### PR TITLE
fix: prevent type error in use entity id

### DIFF
--- a/Plugin/Magento/Sales/Api/Data/OrderExtension.php
+++ b/Plugin/Magento/Sales/Api/Data/OrderExtension.php
@@ -62,7 +62,7 @@ class OrderExtension
         if (! is_numeric(end($explodePath))) {
             [$searchColumn, $searchValue] = $this->useIncrementId();
         } else {
-            [$searchColumn, $searchValue] = $this->useEntityId(end($explodePath));
+            [$searchColumn, $searchValue] = $this->useEntityId((int) end($explodePath));
         }
 
         if (empty($searchValue)) {


### PR DESCRIPTION
We're getting this error a lot;

```
MyParcelNL\Magento\Plugin\Magento\Sales\Api\Data\OrderExtension::useEntityId(): Argument #1 ($entityId) must be of type int, string given, called in /data/web/releases/20230124154227/vendor/myparcelnl/magento/Plugin/Magento/Sales/Api/Data/OrderExtension.php on line 65
```

`useEntityId` expects an int; `private function useEntityId(int $entityId): array`

However, you're exploding a string and not casting it;

```
$explodePath = explode('/', $path ?? '');
[$searchColumn, $searchValue] = $this->useEntityId(end($explodePath));
```

So I added `(int)` to cast the numeric value to an int.
