### PR TITLE
Fix: use correct way to inject search value

### DIFF
--- a/Plugin/Magento/Sales/Api/Data/OrderExtension.php
+++ b/Plugin/Magento/Sales/Api/Data/OrderExtension.php
@@ -73,7 +73,7 @@ class OrderExtension
         $sql = $connection
             ->select('myparcel_delivery_options')
             ->from($tableName)
-            ->where($searchColumn . ' = ' . (int) $searchValue);
+            ->where($searchColumn . ' = ?', $searchValue);
 
         $result = $connection->fetchAll($sql); // Gives associated array, table fields as key in array.
 


### PR DESCRIPTION
When using an order prefix in Magento (like `ORD00000123456` instead of just `00000123456`), the `$searchValue` is cast to an `int`.

This presumably done to avoid SQL injections, so I changed it to using the second parameter of `where()` so Magento escapes it for us and SQL injections are avoided. This way, we can use strings to look for orders with an increment ID instead of only a numeric value.

The resulting query previously resulted in fetching _all_ orders since the `$searchValue` became `0`. Because we have 500k+ orders, this resulted in an out of memory error.