### PR TITLE
fix: use country country codes from sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "type": "magento2-module",
   "require": {
     "php": "^7.1 || ^8.0",
-    "myparcelnl/sdk": "~v7.14.1",
+    "myparcelnl/sdk": "~v7.15.0",
     "magento/framework": ">=101.0.8 <102 || >=102.0.1"
   },
   "require-dev": {


### PR DESCRIPTION
Required for https://github.com/myparcelnl/magento/pull/856 which is already released and broken.
