### PR TITLE
feat: update condition to object with type and value

### DIFF
--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -87,7 +87,6 @@ Maximum weight,Maximum weight
 Country part of,Country part of
 No rules defined. Click Add rule to create a new rule.,No rules defined. Click Add rule to create a new rule.
 Add rule,Add rule
-Rule name,Rule name
 Price,Price
 Toggle conditions,Toggle conditions
 Remove rule,Remove rule
@@ -97,9 +96,5 @@ Condition,Condition
 Value,Value
 Remove condition,Remove condition
 Select a condition,Select a condition
-Carrier name,Carrier name
-Country,Country
-Package type,Package type
-Maximum weight,Maximum weight
-Country part of,Country part of
 New rule,New rule
+Show or hide JSON textarea,Show or hide JSON textarea

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -98,3 +98,4 @@ Remove condition,Remove condition
 Select a condition,Select a condition
 New rule,New rule
 Show or hide JSON textarea,Show or hide JSON textarea
+Invalid JSON in textarea,Invalid JSON in textarea

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -257,3 +257,4 @@ Remove condition,Retirer la condition
 Select a condition,Sélectionnez une condition
 Carrier name,Nom du transporteur
 Show or hide JSON textarea,Afficher ou Masquer la zone de texte JSON
+Invalid JSON in textarea,JSON invalide dans la zone de texte

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -236,3 +236,24 @@ signature_title, Signature à réception
 receipt_code_title, Code de réception
 only_recipient_title, Adresse de résidence uniquement
 saturday_delivery, Livraison le samedi
+Delivery costs,Frais de livraison
+Rule name,Nom de la règle
+Select a condition...,Sélectionnez une condition...
+Carrier name,Nom du transporteur,
+Country,Pays
+Package type,Type de colis,
+Maximum weight,Poids maximum,
+Country part of,Partie du pays,
+No rules defined. Click Add rule to create a new rule.,Aucune règle définie. Cliquez sur Ajouter une règle pour en créer une nouvelle.
+Add rule,Ajouter une règle,
+Price,Prix
+Toggle conditions,Basculer les conditions,
+Remove rule,Retirer la règle,
+Add condition,Ajouter une condition
+New rule,Nouvelle règle,
+Condition,Condition
+Value,Valeur
+Remove condition,Retirer la condition
+Select a condition,Sélectionnez une condition
+Carrier name,Nom du transporteur
+Show or hide JSON textarea,Afficher ou Masquer la zone de texte JSON

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -336,7 +336,6 @@ Maximum weight,Maximum gewicht
 Country part of,Land onderdeel van
 No rules defined. Click Add rule to create a new rule.,Geen regels gedefinieerd. Klik op Regel toevoegen om een nieuwe regel te maken.
 Add rule,Regel toevoegen
-Rule name,Regel naam
 Price,Prijs
 Toggle conditions,Voorwaarden in/uitklappen
 Remove rule,Regel verwijderen
@@ -346,9 +345,4 @@ Condition,Voorwaarde
 Value,Waarde
 Remove condition,Voorwaarde verwijderen
 Select a condition,Selecteer een voorwaarde
-Carrier name,Vervoerder naam
-Country,Land
-Package type,Pakket type
-Maximum weight,Maximum gewicht
-Country part of,Land onderdeel van
-New rule,Nieuwe regel
+Show or hide JSON textarea,Toon of verberg JSON tekstvak

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -346,3 +346,4 @@ Value,Waarde
 Remove condition,Voorwaarde verwijderen
 Select a condition,Selecteer een voorwaarde
 Show or hide JSON textarea,Toon of verberg JSON tekstvak
+Invalid JSON in textarea,Ongeldige JSON in tekstvak

--- a/src/Block/System/Config/Form/DeliveryCostsMatrix.php
+++ b/src/Block/System/Config/Form/DeliveryCostsMatrix.php
@@ -92,6 +92,7 @@ class DeliveryCostsMatrix extends Field
             'Maximum weight' => __('Maximum weight'),
             'Country part of' => __('Country part of'),
             'New rule' => __('New rule'),
+            'Show or hide JSON textarea' => __('Show or hide JSON textarea'),
         ];
     }
 }

--- a/src/Block/System/Config/Form/DeliveryCostsMatrix.php
+++ b/src/Block/System/Config/Form/DeliveryCostsMatrix.php
@@ -93,6 +93,7 @@ class DeliveryCostsMatrix extends Field
             'Country part of' => __('Country part of'),
             'New rule' => __('New rule'),
             'Show or hide JSON textarea' => __('Show or hide JSON textarea'),
+            'Invalid JSON in textarea' => __('Invalid JSON in textarea'),
         ];
     }
 }

--- a/view/adminhtml/web/css/config/delivery_costs_matrix/style.css
+++ b/view/adminhtml/web/css/config/delivery_costs_matrix/style.css
@@ -289,6 +289,45 @@
 
     .show-textarea-container {
         margin: 20px 0 -35px 0;
+        position: relative;
+        width: fit-content;
+
+        &::before {
+            content: "Warning: invalid JSON format causes the matrix to not work.";
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            left: 105%;
+            background-color: #444;
+            color: #fff;
+            padding: 6px 10px;
+            border-radius: 4px;
+            white-space: nowrap;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease-in-out;
+            z-index: 10;
+        }
+
+        &::after {
+            content: "";
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            left: 100%;
+            border-width: 6px;
+            border-style: solid;
+            border-color: transparent #444 transparent transparent;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease-in-out;
+            z-index: 10;
+        }
+
+        &:hover::before,
+        &:hover::after {
+            opacity: 1;
+        }
 
         label {
             padding-right: 10px;

--- a/view/adminhtml/web/css/config/delivery_costs_matrix/style.css
+++ b/view/adminhtml/web/css/config/delivery_costs_matrix/style.css
@@ -1,6 +1,12 @@
 #row_myparcelnl_magento_general_matrix_delivery_costs_ui {
+    .label {
+        @media screen and (max-width: 1510px) {
+            display: none;
+
+        }
+    }
+
     .value {
-        width: 100%;
         padding: 0;
 
         #myparcelnl_magento_general_matrix_delivery_costs_ui {
@@ -9,18 +15,17 @@
     }
 
     .label {
-        display: none;
+        label {
+            display: none;
+        }
     }
 }
 
 #row_myparcelnl_magento_general_matrix_delivery_costs {
     .label {
-        display: none;
-    }
-
-    .value {
-        /* Comment out for checking text area value */
-        display: none;
+        label {
+            display: none;
+        }
     }
 
     .use-default {
@@ -34,20 +39,23 @@
 
     .form-field {
         margin-right: 15px;
+        position: relative;
 
         label {
             color: #303030;
             font-size: 14px;
             font-weight: 600;
             margin-right: 15px;
-            display: inline-block;
+            position: absolute;
+            top: -20px;
+            left: 0;
         }
     }
 
     .rule-header {
         display: flex;
         align-items: center;
-        margin: 10px 0;
+        margin: 30px 0;
 
         .rule-name {
             width: 300px;
@@ -164,7 +172,7 @@
         .condition-row {
             display: flex;
             align-items: center;
-            margin: 10px 0 10px 25px;
+            margin: 30px 0 30px 25px;
 
             select, input {
                 width: 250px;
@@ -275,13 +283,17 @@
     .add-rule-button {
         margin-top: 10px;
     }
-}
 
-.add-rule-button {
+    .show-textarea-container {
+        margin: 20px 0 -35px 0;
 
+        label {
+            padding-right: 10px;
 
-    &:hover {
-        cursor: pointer;
+            &:hover {
+                cursor: pointer;
+            }
+        }
     }
 }
 

--- a/view/adminhtml/web/css/config/delivery_costs_matrix/style.css
+++ b/view/adminhtml/web/css/config/delivery_costs_matrix/style.css
@@ -2,7 +2,6 @@
     .label {
         @media screen and (max-width: 1510px) {
             display: none;
-
         }
     }
 
@@ -23,6 +22,10 @@
 
 #row_myparcelnl_magento_general_matrix_delivery_costs {
     .label {
+        @media screen and (max-width: 1510px) {
+            display: none;
+        }
+
         label {
             display: none;
         }

--- a/view/adminhtml/web/js/delivery-costs-matrix.js
+++ b/view/adminhtml/web/js/delivery-costs-matrix.js
@@ -17,8 +17,7 @@ define(
 
                     // Convert conditions from object format to array format for UI display
                     this.ruleData.forEach(rule => {
-                        if (rule.conditions && typeof rule.conditions === 'object' && !Array.isArray(rule.conditions)) {
-                            // Convert from { "country": "NL", "carrier_name": "ups" } to [{ type: "country", value: "NL" }, { type: "carrier_name", value: "ups" }]
+                        if (rule.conditions && !Array.isArray(rule.conditions)) {
                             rule.conditions = Object.entries(rule.conditions).map(([type, value]) => ({ type, value }));
                         } else if (!rule.conditions) {
                             rule.conditions = [];
@@ -65,12 +64,36 @@ define(
                         this.matrixElement.appendChild(ruleElement);
                     });
 
-                    let addButton = document.createElement('button');
+                    const addButton = document.createElement('button');
                     addButton.type = 'button';
                     addButton.className = 'add-rule-button';
                     addButton.textContent = this.translations['Add Rule'];
                     addButton.addEventListener('click', () => this.addRule());
                     this.matrixElement.appendChild(addButton);
+
+                    const showTextareaContainer = document.createElement('div');
+                    showTextareaContainer.className = 'show-textarea-container';
+                    const showTextareaLabel = document.createElement('label');
+                    showTextareaLabel.textContent = this.translations['Show or hide JSON textarea'];
+                    const showTextareaInput = document.createElement('input');
+                    showTextareaInput.id = 'show-textarea-input';
+                    showTextareaInput.type = 'checkbox';
+                    showTextareaLabel.htmlFor = 'show-textarea-input';
+
+                    const jsonTextarea = document.getElementById('myparcelnl_magento_general_matrix_delivery_costs');
+
+                    // Hide the textarea by default
+                    jsonTextarea.style.display = 'none';
+
+                    showTextareaInput.addEventListener('change', (e) => {
+                        jsonTextarea.style.display = e.target.checked ? 'block' : 'none';
+                    });
+
+                    showTextareaContainer.appendChild(showTextareaLabel);
+                    showTextareaContainer.appendChild(showTextareaInput);
+
+
+                    this.matrixElement.appendChild(showTextareaContainer);
                 },
 
                 // Create a rule element with its conditions
@@ -123,14 +146,10 @@ define(
                         });
                     }
 
-                    // Add a button to add new conditions, if there are less than 5 conditions
-                    const conditionCount = conditionsContainer.querySelectorAll('.condition-row').length
                     const addConditionButton = document.createElement('a');
-                    if (conditionCount < 5) {
-                        addConditionButton.className = 'add-condition-button';
-                        addConditionButton.innerHTML = `<img src="${options.plusIcon}" alt="${this.translations['Add condition']}" title="${this.translations['Add condition']}">`;
-                        conditionsContainer.appendChild(addConditionButton);
-                    }
+                    addConditionButton.className = 'add-condition-button';
+                    addConditionButton.innerHTML = `<img src="${options.plusIcon}" alt="${this.translations['Add condition']}" title="${this.translations['Add condition']}">`;
+                    conditionsContainer.appendChild(addConditionButton);
 
                     // Add event listeners for rule header inputs and buttons
                     header.querySelector(`#rule-name-${ruleId}`).addEventListener('change', (e) => this.updateRuleField(ruleIndex, 'name', e.target.value));
@@ -364,23 +383,7 @@ define(
 
                 // Save the current rule data to the hidden input element
                 save: function() {
-                    // Convert conditions back to object format for saving
-                    const dataToSave = this.ruleData.map(rule => {
-                        const ruleCopy = { ...rule };
-                        if (ruleCopy.conditions && Array.isArray(ruleCopy.conditions)) {
-                            // Convert from [{ type: "country", value: "NL" }, { type: "carrier_name", value: "ups" }] to { "country": "NL", "carrier_name": "ups" }
-                            const conditionsObject = {};
-                            ruleCopy.conditions.forEach(condition => {
-                                if (condition.type && condition.value !== undefined && condition.value !== '') {
-                                    conditionsObject[condition.type] = condition.value;
-                                }
-                            });
-                            ruleCopy.conditions = conditionsObject;
-                        }
-                        return ruleCopy;
-                    });
-
-                    this.hiddenInputElement.value = JSON.stringify(dataToSave, null, 2);
+                    this.hiddenInputElement.value = JSON.stringify(this.ruleData, null, 2);
                 }
             };
 

--- a/view/adminhtml/web/js/delivery-costs-matrix.js
+++ b/view/adminhtml/web/js/delivery-costs-matrix.js
@@ -10,20 +10,6 @@ define(
                     this.matrixElement = document.getElementById('delivery-costs-matrix');
                     this.hiddenInputElement = document.getElementById('myparcelnl_magento_general_matrix_delivery_costs');
 
-                    // Get existing rule data from hidden input and sort it by name
-                    this.ruleData = this.hiddenInputElement.value
-                        ? JSON.parse(this.hiddenInputElement.value).sort((a, b) => (a.name || '').localeCompare(b.name || ''))
-                        : [];
-
-                    // Convert conditions from object format to array format for UI display
-                    this.ruleData.forEach(rule => {
-                        if (rule.conditions && !Array.isArray(rule.conditions)) {
-                            rule.conditions = Object.entries(rule.conditions).map(([type, value]) => ({ type, value }));
-                        } else if (!rule.conditions) {
-                            rule.conditions = [];
-                        }
-                    });
-
                     // Initialize translations and condition options
                     this.translations = JSON.parse(this.options.getTranslations);
                     this.conditionOptionsList = [
@@ -34,6 +20,31 @@ define(
                         {value: 'maximum_weight', text: this.translations['Maximum weight']},
                         {value: 'country_part_of', text: this.translations['Country part of']},
                     ];
+
+                    // This is the first place where the JSON is being parsed, if the JSON is invalid,
+                    // this will be shown to the user and the matrix will not be rendered
+                    try {
+                        // Get existing rule data from hidden input and sort it by name
+                        this.ruleData = this.hiddenInputElement.value
+                            ? JSON.parse(this.hiddenInputElement.value).sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+                            : [];
+                    } catch (e) {
+                        const errorMessage = document.createElement('p');
+                        errorMessage.className = 'error-message';
+                        errorMessage.textContent = this.translations['Invalid JSON in textarea'] + ' ' + e;
+                        this.matrixElement.appendChild(errorMessage);
+                        return;
+                    }
+
+
+                    // Convert conditions from object format to array format for UI display
+                    this.ruleData.forEach(rule => {
+                        if (rule.conditions && !Array.isArray(rule.conditions)) {
+                            rule.conditions = Object.entries(rule.conditions).map(([type, value]) => ({ type, value }));
+                        } else if (!rule.conditions) {
+                            rule.conditions = [];
+                        }
+                    });
 
                     // Track open/closed state of each rule
                     this.openRules = {};


### PR DESCRIPTION
Converting the conditions to an object with type and value enables the user to stash conditions of the same type, e.g. make a rule that is applied to multiple countries, or multiple carriers.

This PR also updates the layout of the UI and adds an option to show / hide the original textarea, enabling users to simply copy-paste the rules between installations.

Resolves: [INT-1105](https://internal.jira.dmp.zone/browse/INT-1105) and [INT-814](https://internal.jira.dmp.zone/browse/INT-814?atlOrigin=eyJpIjoiNDAxMmY3ZTUxNWJhNDZhOThiZDJjY2FkMDNmZGVmNjEiLCJwIjoiaiJ9)

[INT-1105]: https://myparcelnl.atlassian.net/browse/INT-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-814]: https://myparcelnl.atlassian.net/browse/INT-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ