### PR TITLE
fix(ordergrid): show grid with legacy numeric tracktrace numbers

### DIFF
--- a/src/Ui/Component/Listing/Column/TrackAndTrace.php
+++ b/src/Ui/Component/Listing/Column/TrackAndTrace.php
@@ -97,12 +97,12 @@ class TrackAndTrace extends Column
         }
 
         $trackData    = $order->getData('track_number') ?? '';
-        // JSON_BIGINT_AS_STRING prevents large numeric tracking numbers that were stored as single number (not as array) from being misrepresented as floats.
+        // JSON_BIGINT_AS_STRING prevents numeric tracking numbers that were stored as single number (not as array) from being misrepresented as floats.
         $trackNumbers = json_decode($trackData, true, 2, JSON_BIGINT_AS_STRING) ?? $trackData;
 
         // older shipments are stored with '<br>' as separator between trackNumbers
         if (! is_array($trackNumbers)) {
-            $trackNumbers = explode('<br>', $trackNumbers ?? '');
+            $trackNumbers = explode('<br>', (string) $trackNumbers);
         }
 
         foreach ($trackNumbers as $trackNumber) {


### PR DESCRIPTION
Older versions stored the tracktrace numbers not as array but as single value. When retrieved from the db a numeric tracktrace number would be converted to a float by json_decode, this would trip up the explode function further down which expects a string.
By instructing json_decode to return large ints as string, this is mitigated.

INT-1109
