### PR TITLE
fix(checkout): prevent carrier not found error

### DIFF
--- a/src/Model/Carrier/Carrier.php
+++ b/src/Model/Carrier/Carrier.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
 namespace MyParcelNL\Magento\Model\Carrier;
 
 use InvalidArgumentException;
-use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DataObject;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address\RateRequest;


### PR DESCRIPTION
For compatibility reasons we use the Carrier `_code` everywhere for identification, only in 1 place I forgot to change the `_name` (which is dynamic and therefore problematic) to `_code` hence there were scenarios where the identification in the frontend was different from that in the backend. Which resulted in an error obviously.
