### PR TITLE
fix(checkout): prevent shipping_methods loop when interacting with de…

### DIFF
--- a/view/frontend/web/js/view/delivery-options.js
+++ b/view/frontend/web/js/view/delivery-options.js
@@ -141,10 +141,12 @@ define(
         /**
          * Make sure the delivery options are updated when the address is changed in the form, not only in the quote.
          */
+        const debouncedUpdateAddressFromCheckoutData = _.debounce(function(shippingAddressFromData) {
+          deliveryOptions.updateAddress(shippingAddressFromData);
+        }, deliveryOptions.throttleTimeout);
+
         customerData.get('checkout-data').subscribe(function(newData) {
-          _.debounce(function() {
-            deliveryOptions.updateAddress(newData.shippingAddressFromData);
-          }, deliveryOptions.throttleTimeout)();
+          debouncedUpdateAddressFromCheckoutData(newData.shippingAddressFromData);
         });
 
         document.addEventListener(
@@ -176,7 +178,8 @@ define(
           bubbles: true,
           cancelable: false,
           detail: {
-            address: window.MyParcelConfig.address,
+            // shallow copy to prevent loops when Delivery Options enriches the address
+            address: Object.assign({}, window.MyParcelConfig.address),
             config: window.MyParcelConfig.config,
             strings: window.MyParcelConfig.strings,
             selector: '#myparcel-delivery-options'


### PR DESCRIPTION
…livery options

INT-1617
Bug introduced when updating delivery options to V7, which changes the address object.
Pass a shallow copy and use the original for reference only.
Moves debounced outside subscribe defensively, to prevent multiple debounce timers running simultaneously.
