### PR TITLE
fix(checkout): prevent shipping method loop (2)

### DIFF
--- a/view/frontend/web/js/view/delivery-options.js
+++ b/view/frontend/web/js/view/delivery-options.js
@@ -65,7 +65,7 @@ define(
        * Initialize the script. Render the delivery options div, request the plugin settings, then initialize listeners.
        */
       initialize: function() {
-        window.MyParcelConfig.address = deliveryOptions._lastSentAddress = deliveryOptions.getAddress();
+        deliveryOptions._lastSentAddress = deliveryOptions.getAddress();
         checkout.hideShippingMethods();
         deliveryOptions.setToRenderWhenVisible();
         deliveryOptions.addListeners();
@@ -123,13 +123,13 @@ define(
           shippingMethodDiv = document.getElementById('checkout-shipping-method-load');
 
         if (deliveryOptionsDiv) {
-          deliveryOptions.triggerEvent(deliveryOptions.updateDeliveryOptionsEvent);
+          deliveryOptions.triggerEvent(deliveryOptions.updateDeliveryOptionsEvent, deliveryOptions.getAddress());
         } else {
           const newDeliveryOptionsDiv = document.createElement('div');
           newDeliveryOptionsDiv.setAttribute('id', 'myparcel-delivery-options');
           shippingMethodDiv.insertAdjacentElement('afterbegin', newDeliveryOptionsDiv);
           requestAnimationFrame(function() { // wait for the element to actually be added to the DOM
-            deliveryOptions.triggerEvent(deliveryOptions.renderDeliveryOptionsEvent)
+            deliveryOptions.triggerEvent(deliveryOptions.renderDeliveryOptionsEvent, deliveryOptions.getAddress());
           });
         }
 
@@ -178,24 +178,25 @@ define(
        * Trigger an event on the document body.
        *
        * @param {string} identifier - Name of the event.
+       * @param {Object?} address - Address to include in the event detail. Omit for events that do not carry address data.
        */
-      triggerEvent: function(identifier) {
+      triggerEvent: function(identifier, address) {
+        const detail = {
+          config: window.MyParcelConfig.config,
+          strings: window.MyParcelConfig.strings,
+          selector: '#myparcel-delivery-options'
+        };
+        if (address) {
+          detail.address = address;
+        }
         document.body.dispatchEvent(new CustomEvent(identifier, {
           bubbles: true,
           cancelable: false,
-          detail: {
-            // shallow copy to prevent loops when Delivery Options enriches the address
-            address: Object.assign({}, window.MyParcelConfig.address),
-            config: window.MyParcelConfig.config,
-            strings: window.MyParcelConfig.strings,
-            selector: '#myparcel-delivery-options'
-          }
+          detail: detail
         }));
       },
 
       /**
-       * Get address data and put it in the global MyParcelConfig.
-       *
        * @param {Object?} address - Quote.shippingAddress from Magento or checkout-data shipping address from Magento or undefined
        */
       updateAddress: function(address) {
@@ -209,9 +210,7 @@ define(
         }
 
         deliveryOptions._lastSentAddress = newAddress;
-        window.MyParcelConfig.address = newAddress;
-
-        deliveryOptions.triggerEvent(deliveryOptions.updateDeliveryOptionsEvent);
+        deliveryOptions.triggerEvent(deliveryOptions.updateDeliveryOptionsEvent, newAddress);
       },
 
       /**
@@ -328,10 +327,7 @@ define(
       },
 
       updateConfig: function() {
-        if (!window.MyParcelConfig.hasOwnProperty('address')) {
-          window.MyParcelConfig.address = deliveryOptions.getAddress(quote.shippingAddress());
-        }
-        deliveryOptions.triggerEvent(deliveryOptions.updateConfigEvent);
+        deliveryOptions.triggerEvent(deliveryOptions.updateConfigEvent, deliveryOptions.getAddress(quote.shippingAddress()));
       },
     };
 

--- a/view/frontend/web/js/view/delivery-options.js
+++ b/view/frontend/web/js/view/delivery-options.js
@@ -49,6 +49,12 @@ define(
       throttleTimeout: 390, // throttle / debounce timeout in ms.
 
       /**
+       * Last address sent to the widget. Tracked privately so the widget cannot affect the equality
+       * guard by writing back to window.MyParcelConfig.address.
+       */
+      _lastSentAddress: null,
+
+      /**
        * The selector of the field we use to get the delivery options data into the order.
        *
        * @type {string}
@@ -59,6 +65,7 @@ define(
        * Initialize the script. Render the delivery options div, request the plugin settings, then initialize listeners.
        */
       initialize: function() {
+        deliveryOptions._lastSentAddress = null;
         window.MyParcelConfig.address = deliveryOptions.getAddress();
         checkout.hideShippingMethods();
         deliveryOptions.setToRenderWhenVisible();
@@ -198,10 +205,11 @@ define(
         }
 
         const newAddress = deliveryOptions.getAddress(address);
-        if (_.isEqual(newAddress, window.MyParcelConfig.address)) {
+        if (_.isEqual(newAddress, deliveryOptions._lastSentAddress)) {
           return;
         }
 
+        deliveryOptions._lastSentAddress = newAddress;
         window.MyParcelConfig.address = newAddress;
 
         deliveryOptions.triggerEvent(deliveryOptions.updateDeliveryOptionsEvent);

--- a/view/frontend/web/js/view/delivery-options.js
+++ b/view/frontend/web/js/view/delivery-options.js
@@ -65,8 +65,7 @@ define(
        * Initialize the script. Render the delivery options div, request the plugin settings, then initialize listeners.
        */
       initialize: function() {
-        deliveryOptions._lastSentAddress = null;
-        window.MyParcelConfig.address = deliveryOptions.getAddress();
+        window.MyParcelConfig.address = deliveryOptions._lastSentAddress = deliveryOptions.getAddress();
         checkout.hideShippingMethods();
         deliveryOptions.setToRenderWhenVisible();
         deliveryOptions.addListeners();


### PR DESCRIPTION
INT-1637

The previous fix only worked partly, because the D-O also update the global address object. The checkout now tracks the address itself, and sends it as part of the event detail, as intended by the delivery options.
