### PR TITLE
fix(checkout): use correct country for initial delivery options

### DIFF
--- a/view/frontend/web/js/model/checkout.js
+++ b/view/frontend/web/js/model/checkout.js
@@ -195,19 +195,29 @@ function(
      * @returns {XMLHttpRequest}
      */
     calculatePackageType: function(carrier) {
-      function isVisible(el) {
-        return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
-      }
-      const list = document.querySelector('[name="country_id"]'),
-          countryId = (list && isVisible(list)) ? list.options[list.selectedIndex].value : Model.countryId();
       return sendRequest(
         'rest/V1/package_type',
         'GET',
         {
           carrier: carrier,
-          countryCode: countryId,
+          countryCode: Model.resolveCountryId(Model.countryId()),
         }
       );
+    },
+
+    /**
+     * Returns the country id from the checkout form select list country_id, this is Magento standard.
+     * If the element is not shown or present, the fallbackCountryId will be returned.
+     * @param fallbackCountryId
+     * @returns {*}
+     */
+    resolveCountryId: function(fallbackCountryId) {
+      function isVisible(el) {
+        return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+      }
+      const list = document.querySelector('[name="country_id"]');
+
+      return (list && isVisible(list)) ? list.options[list.selectedIndex].value : fallbackCountryId;
     },
 
     /**

--- a/view/frontend/web/js/view/delivery-options.js
+++ b/view/frontend/web/js/view/delivery-options.js
@@ -221,23 +221,18 @@ define(
        */
       getAddress: function(address) {
         address = address || customerData.get('checkout-data')().shippingAddressFromData || quote.shippingAddress() || {};
-        const street = address.street ? [address.street[0], address.street[1]].join(' ').trim() : '',
-          houseNumber = deliveryOptions.getHouseNumber(street),
-          normalizedAddress = {
-            /* checkoutData uses country_id, quote uses countryId */
-            cc: address.country_id || address.countryId || '',
-            postalCode: address.postcode || '',
-            city: address.city || '',
-            street: street
-          };
-        /**
-         * only add the housenumber if it is not null, for the delivery-options will strip it otherwise
-         * which will result in _.isEqual returning false wrongly.
-         */
-        if (houseNumber) {
-          normalizedAddress.number = houseNumber;
-        }
-        return normalizedAddress;
+        /* checkoutData uses country_id, quote uses countryId, but use countryId from checkout form when appropriate */
+        const cc = checkout.resolveCountryId(address.country_id || address.countryId || ''),
+          street = address.street ? [address.street[0], address.street[1]].join(' ').trim() : '',
+          houseNumber = deliveryOptions.getHouseNumber(street);
+
+        return {
+          cc: cc,
+          postalCode: address.postcode || '',
+          city: address.city || '',
+          street: street,
+          houseNumber: houseNumber
+        };
       },
 
       /**


### PR DESCRIPTION
INT-1642
Prioritizes country_id from checkout form when relevant for address used in events towards the delivery options, logic already in use and battle-tested in calculate package type.

Due to a previous fix ( #960 ) we do not have to look out for `null` houseNumbers anymore, as the address is tracked separately now.

