### PR TITLE
fix: honor selected carrier in bulk order actions (INT-1662)

### DIFF
--- a/src/Model/Sales/TrackTraceHolder.php
+++ b/src/Model/Sales/TrackTraceHolder.php
@@ -102,7 +102,18 @@ class TrackTraceHolder
         $order                      = $shipment->getOrder();
         $checkoutData               = $order->getData('myparcel_delivery_options') ?? '[]';
         $deliveryOptions            = $this->jsonSerializer->unserialize($checkoutData) ?? [];
-        $deliveryOptions['carrier'] = $this->getCarrierFromOptions($options) ?? $this->defaultOptions->getCarrierName();
+        $checkoutCarrier            = $deliveryOptions['carrier'] ?? null;
+        $selectedCarrier            = $this->getCarrierFromOptions($options) ?? $this->defaultOptions->getCarrierName();
+        $deliveryOptions['carrier'] = $selectedCarrier;
+
+        // A pickup location is carrier-specific (location code, retail network). If the carrier is
+        // overridden (e.g. in a bulk action) to a different one than was chosen at checkout, the
+        // inherited pickup location is no longer valid — ship as standard home delivery instead.
+        if ($checkoutCarrier && $selectedCarrier !== $checkoutCarrier && ! empty($deliveryOptions['isPickup'])) {
+            unset($deliveryOptions['pickupLocation']);
+            $deliveryOptions['isPickup']     = false;
+            $deliveryOptions['deliveryType'] = AbstractConsignment::DELIVERY_TYPE_STANDARD_NAME;
+        }
 
         $apiKey = $this->config->getGeneralConfig('api/key', $order->getStoreId());
         if (empty($apiKey)) {

--- a/src/Model/Sales/TrackTraceHolder.php
+++ b/src/Model/Sales/TrackTraceHolder.php
@@ -102,7 +102,7 @@ class TrackTraceHolder
         $order                      = $shipment->getOrder();
         $checkoutData               = $order->getData('myparcel_delivery_options') ?? '[]';
         $deliveryOptions            = $this->jsonSerializer->unserialize($checkoutData) ?? [];
-        $deliveryOptions['carrier'] = $this->defaultOptions->getCarrierName();
+        $deliveryOptions['carrier'] = $this->getCarrierFromOptions($options) ?? $this->defaultOptions->getCarrierName();
 
         $apiKey = $this->config->getGeneralConfig('api/key', $order->getStoreId());
         if (empty($apiKey)) {


### PR DESCRIPTION
Fixes INT-1662 in the admin order/shipment grid, the bulk "Print MyParcel labels" action ignored the carrier chosen in the modal and always used the default (PostNL).

## Root cause

`TrackTraceHolder::convertDataFromMagentoToApi()` overwrote the carrier unconditionally:

```php
$deliveryOptions['carrier'] = $this->defaultOptions->getCarrierName();
```

The user's selection (`$options['carrier']`, correctly parsed by `MagentoCollection::setOptionsFromParameters()`) was never consulted. The class already contains a correct resolver — `getCarrierFromOptions()` — but it was dead code, called nowhere. The working PPS/fulfilment path (`MagentoOrderCollection::setFulfilment()`) does the equivalent inline, which is why only this path was broken.

> Note: the "no network call" observation in the ticket is a red herring — the modal submits via a full-page navigation, not an XHR, so nothing shows under the Network XHR/Fetch filter. The carrier value *is* sent.

## Change

Wire line 105 to the existing helper:

```php
$deliveryOptions['carrier'] = $this->getCarrierFromOptions($options) ?? $this->defaultOptions->getCarrierName();
```

Behavior:
- Real carrier selected (e.g. DHL For You) → that carrier is used. ✅ (the bug)
- "Default" selected → resolves via `getCarrierName()` → **identical to before**, no regression.
- No carrier param → default fallback. ✅

Both the order-grid and shipment-grid bulk actions route through this method, so both are fixed by the single change.

## Testing

Verified manually: created an NL order, ran the bulk action as a concept with a non-PostNL carrier, and confirmed the created concept uses the selected carrier; "Default" remains unchanged.

The existing `Test/Unit` suite is integration-style (live Magento + API key, asserts on PDF output) and cannot assert the carrier without new scaffolding, so no automated test is added.
